### PR TITLE
Remove neon dependency

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,4 +7,4 @@
   node_bundler = "esbuild"
 
 [template.environment]
-  NEON_DATABASE_URL = "Postgres connection string from Neon"
+  DATABASE_URL = "Postgres connection string"

--- a/netlify/functions/backup-users.js
+++ b/netlify/functions/backup-users.js
@@ -1,7 +1,9 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });
+const defaultLocalUrl = 'postgres://postgres:postgres@localhost:5432/postgres';
+const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL || process.env.NEON_DATABASE_URL || defaultLocalUrl;
+const pool = new Pool({ connectionString: databaseUrl });
 
 async function ensureTables() {
   await pool.query(`

--- a/netlify/functions/get-backup.js
+++ b/netlify/functions/get-backup.js
@@ -1,7 +1,9 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });
+const defaultLocalUrl = 'postgres://postgres:postgres@localhost:5432/postgres';
+const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL || process.env.NEON_DATABASE_URL || defaultLocalUrl;
+const pool = new Pool({ connectionString: databaseUrl });
 
 async function ensureBackupTable() {
   await pool.query(`

--- a/netlify/functions/get-users.js
+++ b/netlify/functions/get-users.js
@@ -1,7 +1,9 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });
+const defaultLocalUrl = 'postgres://postgres:postgres@localhost:5432/postgres';
+const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL || process.env.NEON_DATABASE_URL || defaultLocalUrl;
+const pool = new Pool({ connectionString: databaseUrl });
 
 async function ensureUsersTable() {
   await pool.query(`

--- a/netlify/functions/restore-backup.js
+++ b/netlify/functions/restore-backup.js
@@ -1,7 +1,9 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });
+const defaultLocalUrl = 'postgres://postgres:postgres@localhost:5432/postgres';
+const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL || process.env.NEON_DATABASE_URL || defaultLocalUrl;
+const pool = new Pool({ connectionString: databaseUrl });
 
 async function ensureTables() {
   await pool.query(`

--- a/netlify/functions/save-users.js
+++ b/netlify/functions/save-users.js
@@ -1,7 +1,9 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });
+const defaultLocalUrl = 'postgres://postgres:postgres@localhost:5432/postgres';
+const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL || process.env.NEON_DATABASE_URL || defaultLocalUrl;
+const pool = new Pool({ connectionString: databaseUrl });
 
 async function ensureUsersTable() {
   await pool.query(`

--- a/netlify/functions/subscribe.js
+++ b/netlify/functions/subscribe.js
@@ -1,7 +1,9 @@
 import pkg from 'pg';
 const { Pool } = pkg;
 
-const pool = new Pool({ connectionString: process.env.NEON_DATABASE_URL });
+const defaultLocalUrl = 'postgres://postgres:postgres@localhost:5432/postgres';
+const databaseUrl = process.env.DATABASE_URL || process.env.POSTGRES_URL || process.env.NEON_DATABASE_URL || defaultLocalUrl;
+const pool = new Pool({ connectionString: databaseUrl });
 
 async function ensureEventsTable() {
   await pool.query(`


### PR DESCRIPTION
Abstract database connection to support any Postgres instance, removing the direct dependency on Neon.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9a1e657-0c0e-49b3-bb98-1198ff4d2825">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9a1e657-0c0e-49b3-bb98-1198ff4d2825">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

